### PR TITLE
docs(contributing): instruct cloning this repo instead of tell-me's

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@
 Then run:
 
 ```sh
-git clone https://github.com/betagouv/tell-me.git
+git clone https://github.com/betagouv/metiers-numeriques.git
 cd tell-me
 yarn
 yarn setup


### PR DESCRIPTION
In `CONTRIBUTING.md` was recommended to clone another repo.

This PR only updates one line: updating the git clone URL.