### PR TITLE
fix: POSTGRES variables names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,11 +18,11 @@ MAILCHIMP_SERVER=""
 # Postgre
 # Only used for test & development purpose and in case of prod deployment via docker-compose
 
-POSTGRE_DATABASE="metiers_numeriques"
-POSTGRE_USERNAME="test_db_user"
-POSTGRE_PASSWORD="test_db_password"
+POSTGRES_DATABASE="metiers_numeriques"
+POSTGRES_USERNAME="test_db_user"
+POSTGRES_PASSWORD="test_db_password"
 # Only used for development purpose
-POSTGRE_PORT="5432"
+POSTGRES_PORT="5432"
 
 ##################################################
 # PEP


### PR DESCRIPTION
Hello, je crois qu'il y a une coquille dans le .env.example sur les noms des vars POSTGRE_xxx versus POSTGRES_xxx.
👉🏼 et du coup petit souci d'incohérence avec la variable POSGRE_PORT qui elle n'a pas le S

Cf : https://github.com/betagouv/metiers-numeriques/pull/345