### PR TITLE
fix: rename institution text columns to match legacy model

### DIFF
--- a/app/molecules/TabMenu.tsx
+++ b/app/molecules/TabMenu.tsx
@@ -22,6 +22,7 @@ const Tab = styled.div<{ selected?: boolean }>`
   font-size: 1.125rem;
   line-height: 1.5rem;
   cursor: pointer;
+  white-space: pre;
 `
 
 type TabProps = {

--- a/app/queries/institution.ts
+++ b/app/queries/institution.ts
@@ -35,11 +35,17 @@ export const GET_ONE = gql`
       url
       pageTitle
       testimonyTitle
+
       description
+      values
       challenges
       mission
-      structure
+      projects
       organisation
+      figures
+      wantedSkills
+      recruitmentProcess
+      workingWithUs
 
       logoFile {
         id

--- a/e2e/302-institutions.spec.ts
+++ b/e2e/302-institutions.spec.ts
@@ -21,7 +21,7 @@ test.describe('Admin > Institutions', () => {
       await page.fill('"Nom *"', testInstitution.name)
       await page.fill('"Site (URL)"', testInstitution.url)
       await page.fill('"Titre"', testInstitution.pageTitle)
-      await page.fill('div[contenteditable="true"]:below(:text("Onglet Description"))', testInstitution.description)
+      await page.fill('div[contenteditable="true"]:below(:text("Notre raison d\'être"))', testInstitution.description)
 
       await page.click('"Créer"')
 

--- a/graphql/institutions.graphql
+++ b/graphql/institutions.graphql
@@ -15,11 +15,17 @@ type Institution {
 
   pageTitle: String
   testimonyTitle: String
+
   description: String
+  values: String
   challenges: String
   mission: String
-  structure: String
+  projects: String
   organisation: String
+  figures: String
+  wantedSkills: String
+  recruitmentProcess: String
+  workingWithUs: String
 
   recruiters: [Recruiter!]!
 }
@@ -44,11 +50,17 @@ input InstitutionInput {
 
   pageTitle: String
   testimonyTitle: String
+
   description: String
+  values: String
   challenges: String
   mission: String
-  structure: String
+  projects: String
   organisation: String
+  figures: String
+  wantedSkills: String
+  recruitmentProcess: String
+  workingWithUs: String
 }
 
 type InstitutionsResult {

--- a/pages/admin/institution/[id].tsx
+++ b/pages/admin/institution/[id].tsx
@@ -110,10 +110,15 @@ export default function AdminInstitutionEditorPage() {
         'pageTitle',
         'testimonyTitle',
         'description',
+        'values',
         'challenges',
         'mission',
-        'structure',
+        'projects',
         'organisation',
+        'figures',
+        'wantedSkills',
+        'recruitmentProcess',
+        'workingWithUs',
       ])(values)
 
       const inputId = isNew ? cuid() : (id as string)
@@ -248,7 +253,7 @@ export default function AdminInstitutionEditorPage() {
           <Field>
             <AdminForm.Editor
               isDisabled={isLoading}
-              label="Onglet Description"
+              label="Notre raison d'être"
               name="description"
               placeholder="Présentez l'institution en quelques mots"
             />
@@ -257,7 +262,16 @@ export default function AdminInstitutionEditorPage() {
           <Field>
             <AdminForm.Editor
               isDisabled={isLoading}
-              label="Onglet Enjeux"
+              label="Nos valeurs"
+              name="values"
+              placeholder="Présentez les valeurs d l'institution en quelques mots"
+            />
+          </Field>
+
+          <Field>
+            <AdminForm.Editor
+              isDisabled={isLoading}
+              label="Nos enjeux"
               name="challenges"
               placeholder="Présentez les enjeux de l'institution en quelques mots"
             />
@@ -266,7 +280,7 @@ export default function AdminInstitutionEditorPage() {
           <Field>
             <AdminForm.Editor
               isDisabled={isLoading}
-              label="Onglet Mission"
+              label="Nos missions"
               name="mission"
               placeholder="Présentez la mission de l'institution en quelques mots"
             />
@@ -275,18 +289,54 @@ export default function AdminInstitutionEditorPage() {
           <Field>
             <AdminForm.Editor
               isDisabled={isLoading}
-              label="Onglet Structure"
-              name="structure"
-              placeholder="Présentez la structure de l'institution en quelques mots"
+              label="Nos projets"
+              name="projects"
+              placeholder="Présentez les projets de l'institution en quelques mots"
             />
           </Field>
 
           <Field>
             <AdminForm.Editor
               isDisabled={isLoading}
-              label="Onglet Organisation"
+              label="Notre organisation"
               name="organisation"
               placeholder="Présentez l'organisation de l'institution en quelques mots"
+            />
+          </Field>
+
+          <Field>
+            <AdminForm.Editor
+              isDisabled={isLoading}
+              label="Nos chiffres clés"
+              name="figures"
+              placeholder="Présentez les chiffres clés de l'institution en quelques mots"
+            />
+          </Field>
+
+          <Field>
+            <AdminForm.Editor
+              isDisabled={isLoading}
+              label="Les profils recherchés"
+              name="wantedSkills"
+              placeholder="Présentez le type de profils recherchés en quelques mots"
+            />
+          </Field>
+
+          <Field>
+            <AdminForm.Editor
+              isDisabled={isLoading}
+              label="Nos process de recrutement"
+              name="recruitmentProcess"
+              placeholder="Présentez le process de recrutement de l'institution en quelques mots"
+            />
+          </Field>
+
+          <Field>
+            <AdminForm.Editor
+              isDisabled={isLoading}
+              label="Nous rejoindre"
+              name="workingWithUs"
+              placeholder="Expliquez pour rejoindre l'institution en quelques mots"
             />
           </Field>
 

--- a/pages/institutions/[slug].tsx
+++ b/pages/institutions/[slug].tsx
@@ -71,17 +71,31 @@ const TestimonyAuthor = styled.div`
 
 type InstitutionTabFields = keyof Pick<
   Institution,
-  'description' | 'challenges' | 'mission' | 'structure' | 'organisation'
+  | 'description'
+  | 'values'
+  | 'challenges'
+  | 'mission'
+  | 'projects'
+  | 'organisation'
+  | 'figures'
+  | 'wantedSkills'
+  | 'recruitmentProcess'
+  | 'workingWithUs'
 >
 
 type Tab = { key: InstitutionTabFields; label: string }
 
 const TABS: Tab[] = [
-  { key: 'description', label: 'Description' },
-  { key: 'challenges', label: 'Enjeux' },
-  { key: 'mission', label: 'Mission' },
-  { key: 'structure', label: 'Structure' },
-  { key: 'organisation', label: 'Organisation' },
+  { key: 'description', label: "Notre raison d'être" },
+  { key: 'values', label: 'Nos valeurs' },
+  { key: 'challenges', label: 'Nos enjeux' },
+  { key: 'mission', label: 'Nos missions' },
+  { key: 'projects', label: 'Nos projets' },
+  { key: 'organisation', label: 'Notre organisation' },
+  { key: 'figures', label: 'Nos chiffres clés' },
+  { key: 'wantedSkills', label: 'Les profils recherchés' },
+  { key: 'recruitmentProcess', label: 'Nos process de recrutement' },
+  { key: 'workingWithUs', label: 'Nous rejoindre' },
 ]
 
 type InstitutionPageProps = {

--- a/prisma/migrations/20220722164032_update_institution_text_fields/migration.sql
+++ b/prisma/migrations/20220722164032_update_institution_text_fields/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `structure` on the `Institution` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Institution" DROP COLUMN "structure",
+ADD COLUMN     "figures" TEXT,
+ADD COLUMN     "projects" TEXT,
+ADD COLUMN     "recruitmentProcess" TEXT,
+ADD COLUMN     "values" TEXT,
+ADD COLUMN     "wantedSkills" TEXT,
+ADD COLUMN     "workingWithUs" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -192,10 +192,15 @@ model Institution {
   pageTitle                       String?
   testimonyTitle                  String?
   description                     String?
+  values                          String?
   challenges                      String?
   mission                         String?
-  structure                       String?
+  projects                        String?
   organisation                    String?
+  figures                         String?
+  wantedSkills                    String?
+  recruitmentProcess              String?
+  workingWithUs                   String?
 
   testimonies                     Testimony[]      @relation("TestimonyInstituion")
   recruiters                      Recruiter[]      @relation("RecruiterInstitution")


### PR DESCRIPTION
[Trello](https://trello.com/c/OUmDnwZJ/115-modifier-les-onglets-des-vitrines-employeur)