### PR TITLE
feat(admin): auto save on blur field instead of using a timeout

### DIFF
--- a/app/molecules/AdminForm/AddressSelect.tsx
+++ b/app/molecules/AdminForm/AddressSelect.tsx
@@ -18,8 +18,9 @@ type AddressSelectProps = {
   isDisabled?: boolean
   label: string
   name: string
+  onBlur?: (values) => void
 }
-export function AddressSelect({ helper, isDisabled = false, label, name }: AddressSelectProps) {
+export function AddressSelect({ helper, isDisabled = false, label, name, onBlur }: AddressSelectProps) {
   const { errors, isSubmitting, setFieldValue, submitCount, touched, values } = useFormikContext<any>()
 
   const [getAddresses] = useLazyQuery(queries.address.GET_ALL, {
@@ -118,6 +119,7 @@ export function AddressSelect({ helper, isDisabled = false, label, name }: Addre
       label={label}
       loadOptions={queryAddress as any}
       name={name}
+      onBlur={onBlur}
       onChange={updateFormikValues as any}
       placeholder={placeholder}
     />

--- a/app/molecules/AdminForm/AutoSave.tsx
+++ b/app/molecules/AdminForm/AutoSave.tsx
@@ -49,6 +49,23 @@ const Spinner = styled.div`
   }
 `
 
+type AutoSaveBoxProps = {
+  isSaving: boolean
+}
+
+export const AutoSaveBox = ({ isSaving }: AutoSaveBoxProps) => {
+  if (!isSaving) {
+    return null
+  }
+
+  return (
+    <Box>
+      <Spinner />
+      <span>Sauvegarde…</span>
+    </Box>
+  )
+}
+
 type AutoSaveProps = {
   onChange: (values: Record<string, any>) => Promise<void>
 }

--- a/app/molecules/AdminForm/ContactSelect.tsx
+++ b/app/molecules/AdminForm/ContactSelect.tsx
@@ -18,6 +18,7 @@ type ContactSelectProps = {
   isMulti?: boolean
   label: string
   name: string
+  onBlur?: (values) => void
   placeholder?: string
 }
 
@@ -27,6 +28,7 @@ export function ContactSelect({
   isMulti = false,
   label,
   name,
+  onBlur,
   placeholder,
 }: ContactSelectProps) {
   const $newContactId = useRef<string>()
@@ -148,6 +150,7 @@ export function ContactSelect({
         isMulti={isMulti}
         label={label}
         name={name}
+        onBlur={onBlur}
         onChange={updateFormikValues as any}
         options={options}
         placeholder={placeholder}

--- a/app/molecules/AdminForm/DomainSelect.tsx
+++ b/app/molecules/AdminForm/DomainSelect.tsx
@@ -8,11 +8,20 @@ type DomainSelectProps = {
   isDisabled?: boolean
   label: string
   name: string
+  onBlur?: (values) => void
   onChange?: (domainIds?: string[]) => void
   placeholder?: string
 }
 
-export function DomainSelect({ helper, isDisabled = false, label, name, onChange, placeholder }: DomainSelectProps) {
+export function DomainSelect({
+  helper,
+  isDisabled = false,
+  label,
+  name,
+  onBlur,
+  onChange,
+  placeholder,
+}: DomainSelectProps) {
   const { errors, isSubmitting, setFieldValue, submitCount, touched, values } = useFormikContext<any>()
 
   const [domains, setDomains] = useState<Common.App.SelectOption[]>([])
@@ -65,6 +74,7 @@ export function DomainSelect({ helper, isDisabled = false, label, name, onChange
       isMulti
       label={label}
       name={name}
+      onBlur={onBlur}
       onChange={updateFormikValues as any}
       options={domains}
       placeholder={placeholder}

--- a/app/molecules/AdminForm/Editor.tsx
+++ b/app/molecules/AdminForm/Editor.tsx
@@ -8,9 +8,10 @@ type EditorProps = {
   isDisabled?: boolean
   label: string
   name: string
+  onBlur?: (values) => void
   placeholder: string
 }
-export function Editor({ helper, isDisabled = false, label, name, placeholder }: EditorProps) {
+export function Editor({ helper, isDisabled = false, label, name, onBlur, placeholder }: EditorProps) {
   const { errors, isSubmitting, setFieldValue, submitCount, touched, values } = useFormikContext<any>()
 
   const hasError = (touched[name] !== undefined || submitCount > 0) && Boolean(errors[name])
@@ -33,6 +34,7 @@ export function Editor({ helper, isDisabled = false, label, name, placeholder }:
       isDisabled={isDisabled || isSubmitting}
       label={label}
       name={name}
+      onBlur={() => onBlur?.(values)}
       onChange={updateFormikValues}
       placeholder={placeholder}
     />

--- a/app/molecules/AdminForm/ProfessionSelect.tsx
+++ b/app/molecules/AdminForm/ProfessionSelect.tsx
@@ -15,6 +15,7 @@ type ProfessionSelectProps = {
   isDisabled?: boolean
   label: string
   name: string
+  onBlur?: (values) => void
   onChange?: (professionId?: string) => void
   placeholder?: string
 }
@@ -24,6 +25,7 @@ export function ProfessionSelect({
   isDisabled = false,
   label,
   name,
+  onBlur,
   onChange,
   placeholder,
 }: ProfessionSelectProps) {
@@ -107,6 +109,7 @@ export function ProfessionSelect({
       isDisabled={isControlledDisabled}
       label={label}
       name={name}
+      onBlur={onBlur}
       onChange={updateFormikValues as any}
       options={options}
       placeholder={placeholder}

--- a/app/molecules/AdminForm/RecruiterSelect.tsx
+++ b/app/molecules/AdminForm/RecruiterSelect.tsx
@@ -21,6 +21,7 @@ type RecruiterSelectProps = {
   isMulti?: boolean
   label: string
   name: string
+  onBlur?: (values) => void
   placeholder?: string
 }
 
@@ -33,6 +34,7 @@ export function RecruiterSelect({
   isMulti = false,
   label,
   name,
+  onBlur,
   placeholder,
 }: RecruiterSelectProps) {
   const $newRecruiterId = useRef<string>()
@@ -155,6 +157,7 @@ export function RecruiterSelect({
         isMulti={isMulti}
         label={label}
         name={name}
+        onBlur={onBlur}
         onChange={updateFormikValues as any}
         options={options}
         placeholder={placeholder}
@@ -174,6 +177,7 @@ export function RecruiterSelect({
         isMulti={isMulti}
         label={label}
         name={name}
+        onBlur={onBlur}
         onChange={updateFormikValues as any}
         options={options}
         placeholder={placeholder}

--- a/app/molecules/AdminForm/Select.tsx
+++ b/app/molecules/AdminForm/Select.tsx
@@ -10,6 +10,7 @@ type SelectProps = {
   isMulti?: boolean
   label: string
   name: string
+  onBlur?: (values) => void
   onChange?: (valueOrValues?: string | string[]) => void
   options?: Common.App.SelectOption[]
   placeholder?: string
@@ -23,6 +24,7 @@ export function Select({
   name,
   options = [],
   onChange,
+  onBlur,
   placeholder,
 }: SelectProps) {
   const { errors, initialValues, isSubmitting, setFieldValue, submitCount, touched, values } = useFormikContext<any>()
@@ -81,6 +83,7 @@ export function Select({
       isMulti={isMulti}
       label={label}
       name={name}
+      onBlur={() => onBlur?.(values)}
       onChange={updateFormikValues as any}
       options={!isAsync ? options : undefined}
       placeholder={placeholder}

--- a/app/molecules/AdminForm/TextInput.tsx
+++ b/app/molecules/AdminForm/TextInput.tsx
@@ -4,9 +4,10 @@ import { ChangeEvent, ChangeEventHandler, useMemo } from 'react'
 
 import type { TextInputProps } from '@singularity/core'
 
-type CustomTextInputProps = TextInputProps & {
+type CustomTextInputProps = Omit<TextInputProps, 'onBlur'> & {
   isDisabled?: boolean
   name: string
+  onBlur?: (values) => Promise<void>
   onChange?: ChangeEventHandler<HTMLInputElement>
   type?: string
 }
@@ -14,6 +15,7 @@ export function TextInput({
   autoComplete = 'off',
   isDisabled = false,
   name,
+  onBlur,
   onChange,
   type = 'text',
   ...props
@@ -39,6 +41,7 @@ export function TextInput({
       disabled={isDisabled || isSubmitting}
       error={maybeError}
       name={name}
+      onBlur={() => onBlur?.(values)}
       onChange={checkChange}
       type={type}
       {...props}

--- a/pages/admin/job/[id]/index.tsx
+++ b/pages/admin/job/[id]/index.tsx
@@ -11,6 +11,7 @@ import { Subtitle } from '@app/atoms/Subtitle'
 import { normalizeDateForDateInput } from '@app/helpers/normalizeDateForDateInput'
 import { showApolloError } from '@app/helpers/showApolloError'
 import { AdminForm } from '@app/molecules/AdminForm'
+import { AutoSaveBox } from '@app/molecules/AdminForm/AutoSave'
 import { Spinner } from '@app/molecules/AdminLoader/Spinner'
 import { StepBar } from '@app/molecules/StepBar'
 import { queries } from '@app/queries'
@@ -106,6 +107,7 @@ export default function AdminJobEditorPage() {
 
   const $state = useRef<JobState | undefined>()
   const $slug = useRef<string | undefined>()
+  const [isSaving, setIsSaving] = useState(false)
   const [initialValues, setInitialValues] = useState<Partial<JobFormData>>()
   const [isError, setIsError] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
@@ -145,6 +147,8 @@ export default function AdminJobEditorPage() {
 
   const save = useCallback(async (values: JobFormData) => {
     try {
+      setIsSaving(true)
+
       const input: Partial<Job> = R.pick([
         'applicationContactIds',
         'applicationWebsiteUrl',
@@ -229,6 +233,8 @@ export default function AdminJobEditorPage() {
     } catch (err) {
       handleError(err, 'pages/admin/job/[id].tsx > save()')
       toast.error(String(err))
+    } finally {
+      setIsSaving(false)
     }
   }, [])
 
@@ -349,11 +355,11 @@ export default function AdminJobEditorPage() {
       {isError && <AdminErrorCard error={ADMIN_ERROR.GRAPHQL_REQUEST} />}
 
       <AdminForm initialValues={initialValues || {}} onSubmit={saveAndGoToList as any} validationSchema={JobFormSchema}>
-        <AdminForm.AutoSave onChange={save as any} />
+        <AutoSaveBox isSaving={isSaving} />
 
         <AdminCard isFirst>
           <Field>
-            <AdminForm.TextInput isDisabled={isLoading} label="Intitulé *" name="title" />
+            <AdminForm.TextInput isDisabled={isLoading} label="Intitulé *" name="title" onBlur={save} />
           </Field>
 
           <DoubleField>
@@ -364,10 +370,17 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Service recruteur *"
               name="recruiterId"
+              onBlur={save}
               placeholder="…"
             />
 
-            <AdminForm.TextInput isDisabled={isLoading} label="Expire le *" name="expiredAtAsString" type="date" />
+            <AdminForm.TextInput
+              isDisabled={isLoading}
+              label="Expire le *"
+              name="expiredAtAsString"
+              onBlur={save}
+              type="date"
+            />
           </DoubleField>
 
           <DoubleField>
@@ -375,6 +388,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Compétence *"
               name="professionId"
+              onBlur={save}
               placeholder="…"
             />
 
@@ -382,13 +396,14 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Types de contrat *"
               name="contractTypes"
+              onBlur={save}
               options={JOB_CONTRACT_TYPES_AS_OPTIONS}
               placeholder="…"
             />
           </DoubleField>
 
           <Field>
-            <AdminForm.DomainSelect isDisabled={isLoading} label="Domaines *" name="domainIds" />
+            <AdminForm.DomainSelect isDisabled={isLoading} label="Domaines *" name="domainIds" onBlur={save} />
           </Field>
 
           <DoubleField>
@@ -396,6 +411,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Années d’expérience requises (0 si ouvert aux débutant·es) *"
               name="seniorityInYears"
+              onBlur={save}
               type="number"
             />
 
@@ -403,12 +419,18 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Télétravail possible *"
               name="remoteStatus"
+              onBlur={save}
               options={JOB_REMOTE_STATUSES_AS_OPTIONS}
               placeholder="…"
             />
           </DoubleField>
 
-          <AdminForm.AddressSelect isDisabled={isLoading} label="Adresse *" name="addressAsPrismaAddress" />
+          <AdminForm.AddressSelect
+            isDisabled={isLoading}
+            label="Adresse *"
+            name="addressAsPrismaAddress"
+            onBlur={save}
+          />
         </AdminCard>
 
         <AdminCard>
@@ -417,6 +439,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Contexte"
               name="contextDescription"
+              onBlur={save}
               placeholder="Contexte de la mission."
             />
           </Field>
@@ -426,6 +449,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Mission *"
               name="missionDescription"
+              onBlur={save}
               placeholder="Décrivez la mission de la manière la plus succinte possible."
             />
           </Field>
@@ -435,6 +459,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="L'équipe"
               name="teamDescription"
+              onBlur={save}
               placeholder="Brève description des rôles et objectifs de l’équipe."
             />
           </Field>
@@ -444,6 +469,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Conditions particulières"
               name="particularitiesDescription"
+              onBlur={save}
               placeholder="Conditions particulières du poste : formations, habilitations, etc."
             />
           </Field>
@@ -453,6 +479,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Avantages"
               name="perksDescription"
+              onBlur={save}
               placeholder="Liste des avantages du poste : opportunités de formation, horaires aménagées, etc."
             />
           </Field>
@@ -464,6 +491,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Tâches"
               name="tasksDescription"
+              onBlur={save}
               placeholder="Liste des tâches principales impliquées par le poste."
             />
           </Field>
@@ -473,6 +501,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Profil idéal de candidat·e"
               name="profileDescription"
+              onBlur={save}
               placeholder="Liste des expériences, qualités et éventuelles qualifications attendues."
             />
           </Field>
@@ -483,6 +512,7 @@ export default function AdminJobEditorPage() {
                 isDisabled={isLoading}
                 label="Rémunération anuelle brut minimum"
                 name="salaryMin"
+                onBlur={save}
                 type="number"
               />
               <span>K€</span>
@@ -493,6 +523,7 @@ export default function AdminJobEditorPage() {
                 isDisabled={isLoading}
                 label="Rémunération anuelle brut maximum"
                 name="salaryMax"
+                onBlur={save}
                 type="number"
               />
               <span>K€</span>
@@ -506,6 +537,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Processus de recrutement"
               name="processDescription"
+              onBlur={save}
               placeholder="Exemple : le processus se déroulera sur 1 mois avec 4 entretiens."
             />
           </Field>
@@ -516,6 +548,7 @@ export default function AdminJobEditorPage() {
               isMulti
               label="Contacts pour l’envoi des candidatures **"
               name="applicationContactIds"
+              onBlur={save}
               placeholder="…"
             />
           </Field>
@@ -525,6 +558,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="site officiel de candidature (URL) **"
               name="applicationWebsiteUrl"
+              onBlur={save}
               type="url"
             />
           </Field>
@@ -534,6 +568,7 @@ export default function AdminJobEditorPage() {
               isDisabled={isLoading}
               label="Contact unique pour les questions *"
               name="infoContactId"
+              onBlur={save}
               placeholder="…"
             />
           </Field>
@@ -544,10 +579,10 @@ export default function AdminJobEditorPage() {
             <Subtitle>Références internes</Subtitle>
 
             <Field>
-              <AdminForm.TextInput isDisabled label="Source" name="source" />
+              <AdminForm.TextInput isDisabled label="Source" name="source" onBlur={save} />
             </Field>
             <FieldGroup>
-              <AdminForm.TextInput isDisabled label="Source (URL)" name="sourceUrl" />
+              <AdminForm.TextInput isDisabled label="Source (URL)" name="sourceUrl" onBlur={save} />
               <button onClick={goToSource} type="button">
                 🔗
               </button>


### PR DESCRIPTION
## Problem
People were having problems with the current auto-save system:
- it saves way too often
- it unfocuses every field you're currently focused on

## Proposed fix
Trigger the `save` method on field blur. 

It's not ideal, but it's way more stable, and solves the focus problem. 