### PR TITLE
fix(web): test on address nullity to avoid missing key access

### DIFF
--- a/app/libs/structuredData/normalizePlace.ts
+++ b/app/libs/structuredData/normalizePlace.ts
@@ -24,7 +24,11 @@ type StructuredDataPlace = {
   }
 }
 
-export function normalizePlace(address: Address): StructuredDataPlace {
+export function normalizePlace(address?: Address): StructuredDataPlace | undefined {
+  if (!address) {
+    return undefined
+  }
+
   return {
     '@type': 'Place',
     address: {

--- a/app/molecules/AdminForm/AddressSelect.tsx
+++ b/app/molecules/AdminForm/AddressSelect.tsx
@@ -31,13 +31,12 @@ export function AddressSelect({ helper, isDisabled = false, label, name, onBlur 
   const maybeError = hasError ? String(errors[name]) : undefined
   const placeholder = 'Ex.: 20 avenue de Ségur'
   const rawValue: any = values[name] ?? null
-  const defaultValue: Common.App.SelectOption<Prisma.AddressCreateInput> | null =
-    rawValue !== null
-      ? {
-          label: `${rawValue.street}, ${rawValue.postalCode} ${rawValue.city}, ${getCountryFromCode(rawValue.country)}`,
-          value: rawValue,
-        }
-      : rawValue
+  const defaultValue: Common.App.SelectOption<Prisma.AddressCreateInput> | null = rawValue
+    ? {
+        label: `${rawValue.street}, ${rawValue.postalCode} ${rawValue.city}, ${getCountryFromCode(rawValue.country)}`,
+        value: rawValue,
+      }
+    : rawValue
 
   const queryAddress = async (query: string): Promise<Common.App.SelectOption<Prisma.AddressCreateInput>[]> => {
     const searchParams = {

--- a/pages/emploi/[slug].tsx
+++ b/pages/emploi/[slug].tsx
@@ -86,10 +86,9 @@ export default function JobPage({ data, isFilledOrExpired, isPreview }: JobPageP
   }, [])
 
   const job = data as JobWithRelation
-  const location =
-    job.address !== null
-      ? `${job.address.street}, ${job.address.city}, ${job.address.region}, ${getCountryFromCode(job.address.country)}`
-      : undefined
+  const location = job.address
+    ? `${job.address.street}, ${job.address.city}, ${job.address.region}, ${getCountryFromCode(job.address.country)}`
+    : undefined
   const pageDescription = job.missionDescription
   const structuredData = !isPreview ? generateJobStructuredData(job) : ''
 


### PR DESCRIPTION
Some unpublished jobs have an uncomplete address. Let's prevent undefined address from creating bugs while accessing it 