### PR TITLE
fix(build): fix build on missing address on Institution

### DIFF
--- a/app/molecules/AdminForm/Editor.tsx
+++ b/app/molecules/AdminForm/Editor.tsx
@@ -29,7 +29,7 @@ export function Editor({ helper, isDisabled = false, label, name, onBlur, placeh
 
   return (
     <MarkdownEditor
-      key={parentKey}
+      key={String(defaultValue)}
       defaultValue={defaultValue}
       error={maybeError}
       helper={helper}
@@ -38,7 +38,7 @@ export function Editor({ helper, isDisabled = false, label, name, onBlur, placeh
       name={name}
       onBlur={() => onBlur?.(values)}
       onChange={updateFormikValues}
-      parentKey={parentKey}
+      parentKey={String(defaultValue)}
       placeholder={placeholder}
     />
   )

--- a/app/organisms/JobCard.tsx
+++ b/app/organisms/JobCard.tsx
@@ -85,7 +85,12 @@ type JobCardProps = {
 }
 
 export function JobCard({ job }: JobCardProps) {
-  const location = job.address.country === 'FR' ? job.address.region : getCountryFromCode(job.address.country)
+  // eslint-disable-next-line no-nested-ternary
+  const location = job.address
+    ? job.address.country === 'FR'
+      ? job.address.region
+      : getCountryFromCode(job.address.country)
+    : 'Non renseigné'
 
   const trackJobOpening = useCallback(() => {
     matomo.trackGoal(MatomoGoal.JOB_OPENING)

--- a/pages/institutions/[slug].tsx
+++ b/pages/institutions/[slug].tsx
@@ -5,7 +5,7 @@ import { TabMenu } from '@app/molecules/TabMenu'
 import { InstitutionHeader, InstitutionWithRelation } from '@app/organisms/InstitutionHeader'
 import { JobCard, JobWithRelation } from '@app/organisms/JobCard'
 import { theme } from '@app/theme'
-import { Institution } from '@prisma/client'
+import { Institution, JobState } from '@prisma/client'
 import Head from 'next/head'
 import * as R from 'ramda'
 import { useState } from 'react'
@@ -235,6 +235,7 @@ export async function getStaticProps({ params: { slug } }) {
       recruiter: {
         institutionId: institution.id,
       },
+      state: JobState.PUBLISHED,
     },
   })
 


### PR DESCRIPTION
[Build](https://dashboard.scalingo.com/apps/osc-secnum-fr1/dinum-metiers-numeriques-prod/deploy/17b77363-ff48-4285-a052-42dbb6821d6b) seems broken because of a missing address.

Let's escape the address to avoid blocking bugs like this in the future. 