### PR TITLE
refactor: add API endpoint helper

### DIFF
--- a/api/libs/endpoint.ts
+++ b/api/libs/endpoint.ts
@@ -1,0 +1,70 @@
+import { UserRole } from '@prisma/client'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getSession } from 'next-auth/react'
+
+type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+
+type Endpoints = {
+  [key in Method]?: {
+    handler: (req: NextApiRequest, res: NextApiResponse) => Promise<void>
+    /** If public, don't fill `permission` */
+    permission?: UserRole | 'ME'
+  }
+}
+
+export const ApiEndpoint = (endpoints: Endpoints) => async (req: NextApiRequest, res: NextApiResponse) => {
+  if (!req.method || !(req.method in endpoints)) {
+    // Page not found
+    return res.status(405).send('Not Allowed')
+  }
+
+  const { handler, permission } = endpoints[req.method]
+
+  if (permission) {
+    const { institutionId, recruiterId, userId } = req.query
+    const session = await getSession({ req })
+
+    if (!session || !session.user) {
+      // Unauthenticated user
+      return res.status(401).send('Unauthorized')
+    }
+
+    const { user } = session
+
+    switch (permission) {
+      case 'ME':
+        if (userId && user.id !== userId) {
+          return res.status(403).send('Forbidden')
+        }
+        break
+      case UserRole.ADMINISTRATOR:
+        if (user.role !== UserRole.ADMINISTRATOR) {
+          // Forbidden
+          return res.status(403).send('Forbidden')
+        }
+        break
+      case UserRole.RECRUITER:
+        if (user.role === UserRole.CANDIDATE) {
+          // Forbidden
+          return res.status(403).send('Forbidden')
+        }
+        if (user.role === UserRole.RECRUITER) {
+          if (institutionId && user.institutionId !== institutionId) {
+            // Forbidden
+            return res.status(403).send('Forbidden')
+          }
+          if (recruiterId && user.recruiterId !== recruiterId) {
+            // Forbidden
+            return res.status(403).send('Forbidden')
+          }
+        }
+        break
+      case UserRole.CANDIDATE:
+        break
+      default:
+        break
+    }
+  }
+
+  return handler(req, res)
+}

--- a/pages/api/applications/[applicationId]/accept.ts
+++ b/pages/api/applications/[applicationId]/accept.ts
@@ -1,18 +1,8 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { handleError } from '@common/helpers/handleError'
 import { JobApplicationStatus } from '@prisma/client'
 import { NextApiRequest, NextApiResponse } from 'next'
-
-export default async function ApiAcceptJobApplicationEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'PUT':
-      return changeJobApplicationStatus(JobApplicationStatus.ACCEPTED)(req, res)
-    case 'DELETE':
-      return changeJobApplicationStatus(JobApplicationStatus.PENDING)(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const changeJobApplicationStatus =
   (status: JobApplicationStatus) => async (req: NextApiRequest, res: NextApiResponse) => {
@@ -30,4 +20,13 @@ const changeJobApplicationStatus =
     }
   }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  DELETE: {
+    handler: changeJobApplicationStatus(JobApplicationStatus.PENDING),
+    permission: 'RECRUITER',
+  },
+  PUT: {
+    handler: changeJobApplicationStatus(JobApplicationStatus.ACCEPTED),
+    permission: 'RECRUITER',
+  },
+})

--- a/pages/api/applications/[applicationId]/duplicate.ts
+++ b/pages/api/applications/[applicationId]/duplicate.ts
@@ -1,16 +1,8 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { handleError } from '@common/helpers/handleError'
 import { NextApiRequest, NextApiResponse } from 'next'
 import * as R from 'ramda'
-
-export default async function ApiDuplicateJobApplicationEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'POST':
-      return duplicateJobApplication(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const duplicateJobApplication = async (req: NextApiRequest, res: NextApiResponse) => {
   const { applicationId } = req.query
@@ -28,4 +20,9 @@ const duplicateJobApplication = async (req: NextApiRequest, res: NextApiResponse
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  POST: {
+    handler: duplicateJobApplication,
+    permission: 'RECRUITER',
+  },
+})

--- a/pages/api/applications/[applicationId]/reject.ts
+++ b/pages/api/applications/[applicationId]/reject.ts
@@ -1,17 +1,9 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { sendJobApplicationRejectedEmail } from '@api/libs/sendInBlue'
 import { handleError } from '@common/helpers/handleError'
 import { JobApplicationStatus } from '@prisma/client'
 import { NextApiRequest, NextApiResponse } from 'next'
-
-export default async function ApiRejectJobApplicationEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'PUT':
-      return rejectJobApplication(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const rejectJobApplication = async (req: NextApiRequest, res: NextApiResponse) => {
   const { applicationId } = req.query
@@ -32,4 +24,9 @@ const rejectJobApplication = async (req: NextApiRequest, res: NextApiResponse) =
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  PUT: {
+    handler: rejectJobApplication,
+    permission: 'RECRUITER',
+  },
+})

--- a/pages/api/applications/index.ts
+++ b/pages/api/applications/index.ts
@@ -1,3 +1,4 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { sendApplicationEmail } from '@api/libs/sendInBlue'
 import { handleError } from '@common/helpers/handleError'
@@ -5,18 +6,6 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { getSession } from 'next-auth/react'
 import * as R from 'ramda'
 
-export default async function ApiJobApplicationsEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'GET':
-      return getJobApplications(req, res)
-    case 'POST':
-      return createOrUpdateJobApplication(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
-
-// TODO: should be paginated at some point
 const getJobApplications = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const session = await getSession({ req })
@@ -144,4 +133,13 @@ const createOrUpdateJobApplication = async (req: NextApiRequest, res: NextApiRes
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  GET: {
+    handler: getJobApplications,
+    permission: 'RECRUITER',
+  },
+  POST: {
+    handler: createOrUpdateJobApplication,
+    permission: 'CANDIDATE',
+  },
+})

--- a/pages/api/auth/forgot-password.ts
+++ b/pages/api/auth/forgot-password.ts
@@ -1,16 +1,8 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { sendResetPasswordEmail } from '@api/libs/sendInBlue'
 import { handleError } from '@common/helpers/handleError'
 import { NextApiRequest, NextApiResponse } from 'next'
-
-export default async function ApiSignUpEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'POST':
-      return handleForgotPassword(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const handleForgotPassword = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -29,4 +21,8 @@ const handleForgotPassword = async (req: NextApiRequest, res: NextApiResponse) =
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  POST: {
+    handler: handleForgotPassword,
+  },
+})

--- a/pages/api/auth/profile.ts
+++ b/pages/api/auth/profile.ts
@@ -1,16 +1,8 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { handleError } from '@common/helpers/handleError'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { getSession } from 'next-auth/react'
-
-export default async function ApiProfileEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'PUT':
-      return updateProfile(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const updateProfile = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getSession({ req })
@@ -114,4 +106,9 @@ const updateProfile = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  PUT: {
+    handler: updateProfile,
+    permission: 'ME',
+  },
+})

--- a/pages/api/auth/request-access.ts
+++ b/pages/api/auth/request-access.ts
@@ -1,17 +1,9 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { sendAccountRequestEmail } from '@api/libs/sendInBlue'
 import { handleError } from '@common/helpers/handleError'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { getSession } from 'next-auth/react'
-
-export default async function ApiProfileEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'POST':
-      return requestRecruiterAccess(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const requestRecruiterAccess = async (req: NextApiRequest, res: NextApiResponse) => {
   const auth = await getSession({ req })
@@ -43,4 +35,9 @@ const requestRecruiterAccess = async (req: NextApiRequest, res: NextApiResponse)
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  POST: {
+    handler: requestRecruiterAccess,
+    permission: 'RECRUITER',
+  },
+})

--- a/pages/api/auth/reset-password.ts
+++ b/pages/api/auth/reset-password.ts
@@ -1,17 +1,9 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { handleError } from '@common/helpers/handleError'
 import jwt from 'jsonwebtoken'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { encryptPassword } from 'pages/api/auth/signup'
-
-export default async function ApiSignUpEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'POST':
-      return resetPassword(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const resetPassword = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -44,4 +36,8 @@ const resetPassword = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  POST: {
+    handler: resetPassword,
+  },
+})

--- a/pages/api/auth/signup.ts
+++ b/pages/api/auth/signup.ts
@@ -1,3 +1,4 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { handleError } from '@common/helpers/handleError'
 import { UserRole } from '@prisma/client'
@@ -5,15 +6,6 @@ import bcryptjs from 'bcryptjs'
 import { NextApiRequest, NextApiResponse } from 'next'
 
 const BCRYPT_SALT_ROUNDS = 10
-
-export default async function ApiSignUpEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'POST':
-      return createAccount(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 export async function encryptPassword(password: string) {
   const salt = await bcryptjs.genSalt(BCRYPT_SALT_ROUNDS)
@@ -42,4 +34,8 @@ const createAccount = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  POST: {
+    handler: createAccount,
+  },
+})

--- a/pages/api/domains/[domainId].ts
+++ b/pages/api/domains/[domainId].ts
@@ -1,17 +1,7 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { handleError } from '@common/helpers/handleError'
 import { NextApiRequest, NextApiResponse } from 'next'
-
-export default async function ApiDomainEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'GET':
-      return getDomain(req, res)
-    case 'PUT':
-      return updateDomain(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const getDomain = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -44,4 +34,13 @@ const updateDomain = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  GET: {
+    handler: getDomain,
+    permission: 'ADMINISTRATOR',
+  },
+  PUT: {
+    handler: updateDomain,
+    permission: 'ADMINISTRATOR',
+  },
+})

--- a/pages/api/domains/index.ts
+++ b/pages/api/domains/index.ts
@@ -1,21 +1,11 @@
 import { buildPrismaPaginationFilter } from '@api/helpers/buildPrismaPaginationFilter'
 import { buildPrismaWhereFilter } from '@api/helpers/buildPrismaWhereFilter'
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { handleError } from '@common/helpers/handleError'
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import type { Prisma, Domain } from '@prisma/client'
-
-export default async function ApiDomainsEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'GET':
-      return getDomains(req, res)
-    case 'POST':
-      return createDomain(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const getDomains = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -67,4 +57,13 @@ const createDomain = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  GET: {
+    handler: getDomains,
+    permission: 'ADMINISTRATOR',
+  },
+  POST: {
+    handler: createDomain,
+    permission: 'ADMINISTRATOR',
+  },
+})

--- a/pages/api/jobs/[id].tsx
+++ b/pages/api/jobs/[id].tsx
@@ -1,15 +1,7 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { handleError } from '@common/helpers/handleError'
 import { NextApiRequest, NextApiResponse } from 'next'
-
-export default async function ApiJobsEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'GET':
-      return getJob(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const getJob = async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query
@@ -20,10 +12,13 @@ const getJob = async (req: NextApiRequest, res: NextApiResponse) => {
 
     res.send(data)
   } catch (err) {
-    handleError(err, 'pages/api/jobs/duplicate.ts > query.getPublishedJobs()')
-
+    handleError(err, 'pages/api/jobs/[id].ts > query.getJob()')
     res.status(400).send([])
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  GET: {
+    handler: getJob,
+  },
+})

--- a/pages/api/jobs/index.tsx
+++ b/pages/api/jobs/index.tsx
@@ -1,16 +1,8 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { handleError } from '@common/helpers/handleError'
 import { JobState } from '@prisma/client'
 import { NextApiRequest, NextApiResponse } from 'next'
-
-export default async function ApiJobsEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'GET':
-      return getPublishedJobs(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const getPublishedJobs = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -25,10 +17,14 @@ const getPublishedJobs = async (req: NextApiRequest, res: NextApiResponse) => {
 
     res.send(data)
   } catch (err) {
-    handleError(err, 'pages/api/jobs/duplicate.ts > query.getPublishedJobs()')
+    handleError(err, 'pages/api/jobs/index.ts > query.getPublishedJobs()')
 
     res.status(400).send([])
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  GET: {
+    handler: getPublishedJobs,
+  },
+})

--- a/pages/api/testimonies/[testimonyId].ts
+++ b/pages/api/testimonies/[testimonyId].ts
@@ -1,17 +1,7 @@
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { handleError } from '@common/helpers/handleError'
 import { NextApiRequest, NextApiResponse } from 'next'
-
-export default async function ApiTestimonyEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'GET':
-      return getTestimony(req, res)
-    case 'PUT':
-      return updateTestimony(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const getTestimony = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -45,4 +35,13 @@ const updateTestimony = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  GET: {
+    handler: getTestimony,
+    permission: 'ADMINISTRATOR',
+  },
+  PUT: {
+    handler: updateTestimony,
+    permission: 'ADMINISTRATOR',
+  },
+})

--- a/pages/api/testimonies/index.ts
+++ b/pages/api/testimonies/index.ts
@@ -1,21 +1,11 @@
 import { buildPrismaPaginationFilter } from '@api/helpers/buildPrismaPaginationFilter'
 import { buildPrismaWhereFilter } from '@api/helpers/buildPrismaWhereFilter'
+import { ApiEndpoint } from '@api/libs/endpoint'
 import { prisma } from '@api/libs/prisma'
 import { handleError } from '@common/helpers/handleError'
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import type { Prisma, Testimony } from '@prisma/client'
-
-export default async function ApiTestimoniesEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'GET':
-      return getTestimonies(req, res)
-    case 'POST':
-      return createTestimony(req, res)
-    default:
-      return defaultResponse(req, res)
-  }
-}
 
 const getTestimonies = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -70,4 +60,13 @@ const createTestimony = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 }
 
-const defaultResponse = (req: NextApiRequest, res: NextApiResponse) => res.status(404)
+export default ApiEndpoint({
+  GET: {
+    handler: getTestimonies,
+    permission: 'ADMINISTRATOR',
+  },
+  POST: {
+    handler: createTestimony,
+    permission: 'ADMINISTRATOR',
+  },
+})


### PR DESCRIPTION
Add an endpoint API helper to help dealing with quick API endpoints & security

### Next steps
- Error Handler
- Move out of GraphQL